### PR TITLE
Relax version constraint for Subclim

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2353,7 +2353,7 @@
 			"details": "https://github.com/JulianEberius/Subclim",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
It is also supported for Sublime 3 as the author of the package confirms here:

https://github.com/JulianEberius/Subclim/issues/19#issuecomment-37093846
